### PR TITLE
Fix colors not updating with dynamic theme

### DIFF
--- a/lib/bmnav.dart
+++ b/lib/bmnav.dart
@@ -40,13 +40,14 @@ class BottomNavState extends md.State<BottomNav> {
   @override
   void initState() {
     currentIndex = widget.index ?? 0;
-    iconStyle = widget.iconStyle ?? IconStyle();
-    labelStyle = widget.labelStyle ?? LabelStyle();
     super.initState();
   }
 
   @override
   md.Widget build(md.BuildContext context) {
+    iconStyle = widget.iconStyle ?? IconStyle();
+    labelStyle = widget.labelStyle ?? LabelStyle();
+    
     return md.Material(
       elevation: widget.elevation,
       color: widget.color,


### PR DESCRIPTION
When using a dynamic theme for light/dark themes, the icon and labels wouldn't update when the theme changes, this just fixes that